### PR TITLE
feat: implement user product retrieval; add online and offline handli…

### DIFF
--- a/lib/data/local/database/database_helper.dart
+++ b/lib/data/local/database/database_helper.dart
@@ -260,6 +260,17 @@ class DatabaseHelper {
     );
   }
 
+  // Obtener productos del usuario desde cached_products
+  Future<List<Map<String, dynamic>>> getCachedUserProducts(String userId) async {
+    final db = await database;
+    return await db.query(
+      'cached_products',
+      where: 'userId = ?',
+      whereArgs: [userId],
+      orderBy: 'timestamp DESC',
+    );
+  }
+
   // —— OPERATIONS ON pending_users —— //
 
   Future<void> savePendingUser(Map<String, dynamic> user) async {

--- a/lib/domain/repositories/product_repository.dart
+++ b/lib/domain/repositories/product_repository.dart
@@ -57,4 +57,7 @@ abstract class ProductRepository {
 
   /// Obtiene los productos de la caché local
   Future<List<Product>> getCachedProducts();
+
+  /// Obtiene los productos del usuario, online u offline
+  Future<List<Product>> getUserProducts(String userId);
 }

--- a/lib/presentation/views/products/my_products_page.dart
+++ b/lib/presentation/views/products/my_products_page.dart
@@ -138,15 +138,14 @@ class _MyProductsPageState extends State<MyProductsPage> {
           ),
           const SizedBox(height: 14),
           Expanded(
-            child: StreamBuilder<List<Product>>(
-              stream: _productRepo.getProductsStream(),
+            child: FutureBuilder<List<Product>>(
+              future: _productRepo.getUserProducts(user.uid),
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
                 }
 
-                final allProducts = snapshot.data ?? [];
-                final myProducts = allProducts.where((p) => p.userId == user.uid).toList();
+                final myProducts = snapshot.data ?? [];
 
                 final displayedProducts = searchQuery.isEmpty
                     ? myProducts


### PR DESCRIPTION
This pull request introduces functionality to fetch a user's products either from an online source (Firestore) or offline (local cache), depending on connectivity. The most important changes include adding a new method to query cached user products, implementing the logic to fetch user products in the repository, updating the repository interface, and modifying the UI to use this new functionality.